### PR TITLE
Enh/add data fetchers

### DIFF
--- a/examples/eg003r__fitting_rww_example.py
+++ b/examples/eg003r__fitting_rww_example.py
@@ -24,6 +24,7 @@ from whobpyt.datatypes import par, Recording
 from whobpyt.models.RWW import RNNRWW, ParamsRWW
 from whobpyt.optimization.custom_cost_RWW import CostsRWW
 from whobpyt.run import Model_fitting
+from whobpyt.data import fetch_hcpl2k8
 
 # array and pd stuff
 import numpy as np
@@ -38,19 +39,32 @@ import matplotlib.pyplot as plt
 import gdown
 # %%
 # define destination path and download data
+
+
+"""
 des_dir = '../'
 if not os.path.exists(des_dir):
     os.makedirs(des_dir)  # create folder if it does not exist
 url = "https://drive.google.com/drive/folders/18smy3ElTd4VksoL4Z15dhwT5l3yjk6xS"
 os.chdir(des_dir)
 gdown.download_folder(url, remaining_ok = True)
-os.chdir('examples/')
+"""
 
+# Go to examples folder
+#os.chdir('examples')
+
+
+# Download the data for this example to default location ~/.whobpyt/data
+data_dir = fetch_hcpl2k8()
+
+base_dir = os.path.join(data_dir, 'HCP')
 
 # %%
 #get subject list
-base_dir = '../HCP/'
+#base_dir = '../HCP/'
+
 #subs =sorted([sc_file[-10:-4] for sc_file in os.listdir(base_dir) if sc_file[:8] == 'weights_'])
+
 sub = '100307'
 
 
@@ -69,8 +83,8 @@ repeat_size = 5
 
 # %%
 # load raw data and get SC empirical BOLD and FC
-sc_file = base_dir + 'weights_' + sub + '.txt'
-ts_file = base_dir + sub + '_rfMRI_REST1_LR_hpc200_clean__l2k8_sc33_ts.pkl'  # out_dir+'sub_'+sub+'simBOLD_idt.txt'#
+sc_file = os.path.join(base_dir, 'weights_' + sub + '.txt')
+ts_file = os.path.join(base_dir, sub + '_rfMRI_REST1_LR_hpc200_clean__l2k8_sc33_ts.pkl')  # out_dir+'sub_'+sub+'simBOLD_idt.txt'#
 
 
 sc = np.loadtxt(sc_file)

--- a/whobpyt/data/__init__.py
+++ b/whobpyt/data/__init__.py
@@ -1,0 +1,4 @@
+
+from .fetchers import fetch_hcpl2k8
+
+

--- a/whobpyt/data/fetchers.py
+++ b/whobpyt/data/fetchers.py
@@ -1,0 +1,97 @@
+# ------------------------------------
+# WhobPyT Data Fetcher Functionalities
+# ------------------------------------
+#
+# Modified directly from code in grifflab/kernel-flow-tools
+# Inspired by nilearn & mne
+#
+
+# Importage
+import os,sys,glob,shutil,numpy as np, pandas as pd
+import requests, zipfile,gdown
+from datetime import datetime
+
+WHOBPYT_DATA_FOLDER = '~/.whobpyt/data'
+
+
+def get_localdefaultdatapath():
+    return os.path.expanduser(WHOBPYT_DATA_FOLDER)
+
+
+def pull_file(dlcode,destination,download_method):
+
+  dest_file = destination.split('/')[-1]
+  print('\n\nDownloading %s\n' %dest_file)
+
+  if download_method == "gdown":
+
+    url = "https://drive.google.com/uc?id=" + dlcode
+    gdown.download(url, destination, quiet=False)
+
+
+  elif download_method == "requests":
+
+    url = "https://docs.google.com/uc?export=download"
+
+    session = requests.Session()
+    response = session.get(
+    url, params={"id": dlcode}, stream=True)
+
+    # get the confirmation token to download large files
+    token = None
+    for key, value in response.cookies.items():
+      if key.startswith("download_warning"):
+        token = value
+
+    if token:
+      params = {"id": id, "confirm": token}
+      response = session.get(url, params=params, stream=True)
+
+    # save content to the zip-file  
+    CHUNK_SIZE = 32768
+    with open(destination, "wb") as f:
+      for chunk in response.iter_content(CHUNK_SIZE):
+        if chunk:
+          f.write(chunk)
+
+
+def pull_folder(dlcode: str, newfolder_name: str, dest_folder = None):
+
+    # Creates a new folder `newfolder_name` inside `dest_folder`, 
+    # downloads the data into that location, 
+    # and returns the location as a string
+
+    # Assemble gdown gdrive url target
+    url = "https://drive.google.com/drive/folders/" + dlcode
+  
+    # (dest_folder is the location this folder will be downloaded into)
+
+    # if no dest folder supplied, use the default location in user's home    
+    if dest_folder is None: dest_folder = get_localdefaultdatapath()
+    newfolder = os.path.join(dest_folder, newfolder_name)
+
+    # Create dest folder if it does not exist
+    if not os.path.exists(newfolder): os.makedirs(newfolder) 
+
+    # cd to dest folder, grab the download, cd back to current dir  
+    cwd = os.getcwd()
+    os.chdir(newfolder)
+    gdown.download_folder(url, remaining_ok=True)
+    os.chdir(cwd)
+
+    print('\n\nDownloaded \n\n%s \n\nto \n\n%s\n\n' %(url,newfolder))           
+    return newfolder
+
+
+def fetch_hcpl2k8(dest_folder = None):
+
+    dlcode = "18smy3ElTd4VksoL4Z15dhwT5l3yjk6xS"
+
+    res_location = pull_folder(dlcode, dest_folder=dest_folder, 
+                               newfolder_name = 'hcpl2k8')
+
+    return res_location
+
+   
+
+ 

--- a/whobpyt/data/fetchers.py
+++ b/whobpyt/data/fetchers.py
@@ -118,7 +118,8 @@ def fetch_MomiEtAlELife2023(dest_folder=None):
 
     # Pull the data folder
     newf_name = ''
-    dlcode = '1iwsxrmu_rnDCvKNYDwTskkCNt709MPuF'
+    dlcode = '1t-9m0E88xUUcGWWH024H32maQUs_Jjgx'  # This is the DATA_LITE folder
+    # dlcode = '1iwsxrmu_rnDCvKNYDwTskkCNt709MPuF' This is the FULL data folder (too large to download)
     res_loc_1 = pull_folder(dlcode, dest_folder=dest_folder,newfolder_name=newf_name)
 
     # Pull the fsaverage folder

--- a/whobpyt/data/fetchers.py
+++ b/whobpyt/data/fetchers.py
@@ -94,4 +94,40 @@ def fetch_hcpl2k8(dest_folder = None):
 
    
 
- 
+
+def fetch_MomiEtAlELife2023(dest_folder=None):
+    #
+    # -----
+    # Usage
+    # -----
+    #
+    # thisdir = os.getcwd()
+    # dest_folder = os.path.join(thisdir,'reproduce_Momi_et_al_2023')
+    #
+    # res = fetch_MomiEtAlElife2023(dest_folder=dest_folder)
+    #
+
+    cwd = os.getcwd()
+   
+    # Life hack to stop for erroring on the next line
+    if dest_folder is None: dest_folder = ''
+
+    # Create the target out dir
+    if not os.path.isdir(dest_folder): os.makedirs(dest_folder)
+    os.chdir(dest_folder)
+
+    # Pull the data folder
+    newf_name = ''
+    dlcode = '1iwsxrmu_rnDCvKNYDwTskkCNt709MPuF'
+    res_loc_1 = pull_folder(dlcode, dest_folder=dest_folder,newfolder_name=newf_name)
+
+    # Pull the fsaverage folder
+    newf_name = '' 
+    dlcode = '1YPyf3h9YKnZi0zRwBwolROQuqDtxEfzF'
+    res_loc_2 = pull_folder(dlcode, dest_folder=dest_folder,newfolder_name=newf_name)
+
+    # Confirm you got everything and go back to initial dir
+    os.chdir(cwd)
+
+
+


### PR DESCRIPTION

Created data fetchers basic functions and first examples. 

Modified rww fitting example to use new fetcher `hcpl2k8` 

Note also: default location for fetched data in user's home (`~'/.whobpyt/data`), unless specified otherwise in fetcher call. 

This is consistent with general convention across MNE, Nilearn, Dipy, etc. ; although note that this folder can get quite large, so in general I prefer and recommend to not use the default location for these libraries. That however is not directly relevant to this PR's functionality, and using home as default does keep things nice and neat. 

Some further tidy up of rww example code + text to follow in a later PR

