### PR TITLE
Adding the GitHub Codespaces `devcontainers` support to our repo.

### DIFF
--- a/.devcontainer/python-cpu-devcontainer/devcontainer.json
+++ b/.devcontainer/python-cpu-devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+    "name": "python_whobpyt",
+    "image": "mcr.microsoft.com/devcontainers/python:3.9",
+      
+    "customizations": {
+      "vscode": {
+        "extensions": [
+          "ms-python.python"
+        ],
+        "settings": {
+          "python.pythonPath": "/usr/local/bin/python"
+        }
+      }
+    },
+  
+    "forwardPorts": [
+      8000
+    ],
+    "postCreateCommand": "pip install -r requirements.txt && pip install . && echo 'Dependencies installed'",
+    "appPort": 8000
+  
+  }

--- a/.devcontainer/python-docs-devcontainer/devcontainer.json
+++ b/.devcontainer/python-docs-devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+    "name": "python_whobpyt",
+    "image": "mcr.microsoft.com/devcontainers/python:3.9",
+      
+    "customizations": {
+      "vscode": {
+        "extensions": [
+          "ms-python.python"
+        ],
+        "settings": {
+          "python.pythonPath": "/usr/local/bin/python"
+        }
+      }
+    },
+  
+    "forwardPorts": [
+      8000
+    ],
+    "postCreateCommand": "pip install -r requirements.txt && pip install . && echo 'Dependencies installed' && cd doc && mkdir _static && echo 'Created _static directory' && make html && echo 'HTML documentation built'",
+    "appPort": 8000
+  
+  }

--- a/.devcontainer/python-gpu-devcontainer/devcontainer.json
+++ b/.devcontainer/python-gpu-devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+    "name": "python_whobpyt",
+    "image": "mcr.microsoft.com/devcontainers/python:3.9",
+      
+    "customizations": {
+      "vscode": {
+        "extensions": [
+          "ms-python.python"
+        ],
+        "settings": {
+          "python.pythonPath": "/usr/local/bin/python"
+        }
+      }
+    },
+    
+    "hostRequirements": {"gpu":true,
+                        "cpus": 4},
+  
+    "forwardPorts": [
+      8000
+    ],
+    "postCreateCommand": "pip install -r requirements.txt && pip install . && echo 'Dependencies installed' && cd doc && mkdir _static && echo 'Created _static directory' && make html && echo 'HTML documentation built'",
+    "appPort": 8000
+  
+  }


### PR DESCRIPTION
Adding the features for `devcontainers`
- To be used with github codespaces.
- Try "reviewing this PR in codespaces"
- From the Command Pallette, select "rebuild devcontainer", and choose the "docs" or "cpu" ones. GPU is not supported yet due to account payment type, but the devcontainer exists for when it needs to be used.