### PR TITLE
Add test workflow checking html build w/o deploy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: test
+# testing the package by building the html help files.
+
+on:
+    push:
+        branches: [ dev, 'dev/*', 'feat/*', 'fix/*', 'hotfix/*', 'enh/*', 'misc/*' ]
+    pull_request:
+        branches: [ main, dev ]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v2
+        - name: Set up Python
+          uses: actions/setup-python@v1
+          with:
+            python-version: 3.9
+        - name: Install dependencies
+          run: |
+            pip install -r requirements.txt
+            pip install .
+        - name: Build docs
+          run: |
+            cd doc
+            mkdir _static
+            make html


### PR DESCRIPTION
Adding testing workflow so that we won't need to rely on docs builds.

Bare minimum:
- [x] Builds on pushes before merging and without deploying
  (for pushes to main/dev or any branches with patterns `['dev/*', 'feat/*', 'fix/*', 'hotfix/*', 'enh/*', 'misc/*']`.

Next steps:
- [ ] Check the types in this test (as implemented by @kevinkadak).
- [ ] *Ninja level*: Check outputs of notebooks/examples to see if they're in a good range.