### PR TITLE
change sphinx version in `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,13 +12,12 @@ mne
 
 
 # Docs requirements
-sphinx
-#sphinx==3.1.1
-sphinx-gallery==0.8.1
-sphinx_rtd_theme==0.5.0
-sphinx-tabs==1.3.0
-sphinx-copybutton==0.3.1
-sphinxcontrib-httpdomain==1.7.0
+sphinx==5.0.0
+sphinx-gallery==0.15.0
+sphinx_rtd_theme==2.0.0
+sphinx-tabs==3.4.4
+sphinx-copybutton==0.5.2
+sphinxcontrib-httpdomain==1.8.1
 numpydoc==1.1.0
 recommonmark==0.6.0
 versioneer==0.19


### PR DESCRIPTION
- Fixing the doc build failure
- Rooted in probable change in upstream PyPi code pulled.