### PR TITLE
fixed LM prior settings

### DIFF
--- a/whobpyt/datatypes/AbstractNMM.py
+++ b/whobpyt/datatypes/AbstractNMM.py
@@ -42,7 +42,7 @@ class AbstractNMM(torch.nn.Module):
             if (var.fit_par):
                 if var_name == 'lm':
                     size = var.val.shape
-                    var.val = Parameter(- 1 * torch.ones((size[0], size[1])) + 0.1*torch.randn(size[0], size[1])) 
+                    var.val = Parameter(var.val) 
                     var.prior_mean = Parameter(var.prior_mean)
                     var.prior_precision = Parameter(var.prior_precision)
                     param_reg.append(var.val)


### PR DESCRIPTION
Changed the code so that if in the params class, for the lm, `fit_par==True` then use the prior leadfield that is passed as opposed to initializing a matrix of ones.