### PR TITLE
fixing info pickle load bug

### DIFF
--- a/examples/eg__ismail2026.py
+++ b/examples/eg__ismail2026.py
@@ -154,7 +154,7 @@ print("Finished fitting model to noise trials")
 verb_meg_sim = np.load(os.path.join(output_dir, 'sim_verb_sensor.npy'))
 noise_meg_sim = np.load(os.path.join(output_dir, 'sim_noise_sensor.npy'))
 # Use existing MEG channel structure to use MNE format
-with open(os.path.join(output_dir, 'info.pkl'), 'rb') as f:
+with open(os.path.join(output_dir, 'info_nosubjinfo.pkl'), 'rb') as f:
     info = pickle.load(f)
 # Convert empirical data to MNE format
 emp_verb_evoked = mne.EvokedArray(verb_meg[:, 0:], info, tmin=-0.1)

--- a/whobpyt/datasets/fetchers.py
+++ b/whobpyt/datasets/fetchers.py
@@ -329,6 +329,7 @@ def fetch_egismail2026(dest_folder=None, redownload=False):
                   'dbwp9': 'emp_noise_source.npy',
                   'h6gjx': 'emp_verb_source.npy',
                   '5e68s': 'info.pkl',
+                  's6wvn': 'info_nosubjinfo.pkl',
                   'rkzjw': 'leadfield_3d.mat',
                   'edcg2': 'noise_evoked.npy',
                   'gmr72': 'sim_noise_sensor.npy',


### PR DESCRIPTION

for some installations I am getting an error when trying to read the `info.pkl`. This fixes this with a modified `.pkl` file added to the data fetcher and the example script. 